### PR TITLE
Fix [authorization_request_not_found] error

### DIFF
--- a/src/main/java/com/example/redditoauth/SecurityConfig.java
+++ b/src/main/java/com/example/redditoauth/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.example.redditoauth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(a -> a
+                .antMatchers("/", "/error").permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2Login(o -> o
+                .failureHandler((request, response, exception) -> {
+                    request.getSession().setAttribute("error.message", exception.getMessage());
+                    handler.onAuthenticationFailure(request, response, exception);
+                })
+                .authorizationEndpoint(a -> a
+                        .authorizationRequestRepository(new HttpSessionOAuth2AuthorizationRequestRepository())
+                )
+            );
+        return http.build();
+    }
+
+    private final SimpleUrlAuthenticationFailureHandler handler = new SimpleUrlAuthenticationFailureHandler("/");
+
+}


### PR DESCRIPTION
The [authorization_request_not_found] error is caused by the authorization request being lost between the authorization request and the callback. This is often due to session persistence issues.

This commit fixes the error by replacing the default `HttpSessionOAuth2AuthorizationRequestRepository` with a new instance of `HttpSessionOAuth2AuthorizationRequestRepository` to ensure that the authorization request is stored in the session correctly.